### PR TITLE
Echo e option

### DIFF
--- a/src/core/echo.js
+++ b/src/core/echo.js
@@ -1,12 +1,93 @@
 const { parse } = require('./parse_args');
 
+function _interpretEscapes(s) {
+  let out = '';
+  let suppressed = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === '\\') {
+      i++;
+      if (i >= s.length) break;
+      const nxt = s[i];
+      switch (nxt) {
+        case 'a': out += '\x07'; break;
+        case 'b': out += '\b'; break;
+        case 'c': suppressed = true; i = s.length; break;
+        case 'e': case 'E': out += '\x1b'; break;
+        case 'f': out += '\f'; break;
+        case 'n': out += '\n'; break;
+        case 'r': out += '\r'; break;
+        case 't': out += '\t'; break;
+        case 'v': out += '\v'; break;
+        case '\\': out += '\\'; break;
+        case '0': {
+          let oct = '';
+          let j = i + 1;
+          while (j < s.length && oct.length < 3 && /[0-7]/.test(s[j])) {
+            oct += s[j++];
+          }
+          if (oct) {
+            out += String.fromCharCode(parseInt(oct, 8));
+            i = j - 1;
+          } else {
+            out += '\0';
+          }
+          break;
+        }
+        case 'x': {
+          let hex = '';
+          let j = i + 1;
+          while (j < s.length && hex.length < 2 && /[0-9A-Fa-f]/.test(s[j])) {
+            hex += s[j++];
+          }
+          if (hex) {
+            out += String.fromCharCode(parseInt(hex, 16));
+            i = j - 1;
+          } else {
+            out += 'x';
+          }
+          break;
+        }
+        default:
+          out += nxt;
+      }
+    } else {
+      out += ch;
+    }
+  }
+  return { str: out, suppressed };
+}
+
 function main({ args = [], stdin = '', env = {} }) {
+  const eHelp = `enable interpretation of backslash escapes
+  \\\\      backslash
+  \\a      alert (BEL)
+  \\b      backspace
+  \\c      produce no further output
+  \\e      escape
+  \\f      form feed
+  \\n      new line
+  \\r      carriage return
+  \\t      horizontal tab
+  \\v      vertical tab
+  \\0NNN   byte with octal value NNN (1 to 3 digits)
+  \\xHH    byte with hexadecimal value HH (1 to 2 digits)`;
   const optionSpec = [
-    { key: 'no_newline', short_tag: 'n', spec: 'flag', help: 'do not output the trailing newline' }
+    { key: 'no_newline', short_tag: 'n', spec: 'flag', help: 'do not output the trailing newline' },
+    { key: 'interpret_escapes', short_tag: 'e', spec: 'flag', help: eHelp }
   ];
   const { options, operands } = parse(args, optionSpec);
   const noNl = options.no_newline === true;
-  const stdout = operands.join(' ') + (noNl ? '' : '\n');
+  const interp = options.interpret_escapes === true;
+  let stdout;
+  if (interp) {
+    const input = operands.join(' ');
+    const { str, suppressed } = _interpretEscapes(input);
+    stdout = str;
+    if (!suppressed && !noNl) stdout += '\n';
+  } else {
+    stdout = operands.join(' ') + (noNl ? '' : '\n');
+  }
   const stderr = '';
   const newEnv = Object.assign({}, env, { '?': 0 });
   return { stdout, stderr, env: newEnv };

--- a/src/core/echo.js
+++ b/src/core/echo.js
@@ -27,7 +27,7 @@ function _interpretEscapes(s) {
             oct += s[j++];
           }
           if (oct) {
-            out += String.fromCharCode(parseInt(oct, 8));
+            out += String.fromCharCode(Number.parseInt(oct, 8));
             i = j - 1;
           } else {
             out += '\0';
@@ -41,7 +41,7 @@ function _interpretEscapes(s) {
             hex += s[j++];
           }
           if (hex) {
-            out += String.fromCharCode(parseInt(hex, 16));
+            out += String.fromCharCode(Number.parseInt(hex, 16));
             i = j - 1;
           } else {
             out += 'x';

--- a/tests/echo.test.js
+++ b/tests/echo.test.js
@@ -3,11 +3,64 @@ const klsh = require('../dist/klsh.js');
 
 describe('echo', function() {
   it('returns the same string', function() {
-    const result = klsh.echo.main({ args: ['hello', 'world'], stdin: "", env: {} });
-    expect(result).to.deep.equal({stdout: "hello world\n", stderr: "", env: {'?': 0}});
+    const result = klsh.echo.main({ args: ['hello', 'world'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: 'hello world\n', stderr: '', env: {'?': 0}});
   });
   it('no new line', function() {
-    const result = klsh.echo.main({ args: ['-n', 'hello', 'world'], stdin: "", env: {} });
-    expect(result).to.deep.equal({stdout: "hello world", stderr: "", env: {'?': 0}});
+    const result = klsh.echo.main({ args: ['-n', 'hello', 'world'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: 'hello world', stderr: '', env: {'?': 0}});
+  });
+  it('interprets backslash escapes with -e', function() {
+    const result = klsh.echo.main({ args: ['-e', 'foo\\nbar'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: 'foo\nbar\n', stderr: '', env: {'?': 0}});
+  });
+  // Detailed -e escape sequence tests
+  it('interprets backslash (\\) escape', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\\\'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: '\\\n', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\a as alert (BEL)', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\a'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: '\x07\n', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\b as backspace', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\b'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: '\b\n', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\c to suppress further output', function() {
+    const result = klsh.echo.main({ args: ['-e', 'foo\\cbar'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: 'foo', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\e as escape', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\e'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: '\x1b\n', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\f as form feed', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\f'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: '\f\n', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\n as new line', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\n'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: '\n\n', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\r as carriage return', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\r'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: '\r\n', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\t as horizontal tab', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\t'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: '\t\n', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\v as vertical tab', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\v'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: '\v\n', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\0NNN as octal', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\040'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: ' \n', stderr: '', env: {'?': 0}});
+  });
+  it('interprets \\xHH as hexadecimal', function() {
+    const result = klsh.echo.main({ args: ['-e', '\\x41'], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: 'A\n', stderr: '', env: {'?': 0}});
   });
 });

--- a/tests/parse_args.test.js
+++ b/tests/parse_args.test.js
@@ -3,8 +3,8 @@ const klsh = require('../dist/klsh.js');
 
 describe('parse_args', function() {
   it('main is not implemented', function() {
-    const result = klsh.parse_args.main({ args: [], stdin: "", env: {} });
-    expect(result).to.deep.equal({stdout: "", stderr: "Not implemented\n", env: {'?': 1}});
+    const result = klsh.parse_args.main({ args: [], stdin: '', env: {} });
+    expect(result).to.deep.equal({stdout: '', stderr: 'Not implemented\n', env: {'?': 1}});
   });
   it('parse non option args', function() {
     const result = klsh.parse_args.parse(['hello', 'world'], []);
@@ -13,11 +13,11 @@ describe('parse_args', function() {
   it('parse flags', function() {
     const option_spec = [
         {
-            key: "print_version",
-            short_tag: "V",
-            long_tag: "version",
-            spec: "flag",
-            help: "output version information and exit"
+            key: 'print_version',
+            short_tag: 'V',
+            long_tag: 'version',
+            spec: 'flag',
+            help: 'output version information and exit'
         }
     ];
     let result;
@@ -33,9 +33,9 @@ describe('parse_args', function() {
 
   it('parse bundled flags', function() {
     const option_spec = [
-        { key: "a_flag", short_tag: "a", long_tag: "alpha", spec: "flag", help: "" },
-        { key: "b_flag", short_tag: "b", long_tag: "beta", spec: "flag", help: "" },
-        { key: "c_flag", short_tag: "c", long_tag: "gamma", spec: "flag", help: "" }
+        { key: 'a_flag', short_tag: 'a', long_tag: 'alpha', spec: 'flag', help: '' },
+        { key: 'b_flag', short_tag: 'b', long_tag: 'beta', spec: 'flag', help: '' },
+        { key: 'c_flag', short_tag: 'c', long_tag: 'gamma', spec: 'flag', help: '' }
     ];
     const result = klsh.parse_args.parse(['-abc', 'world'], option_spec);
     expect(result).to.deep.equal({options: {a_flag: true, b_flag: true, c_flag: true}, operands: ['world'], unknown: []});
@@ -43,11 +43,11 @@ describe('parse_args', function() {
   it('parse string options', function() {
     const option_spec = [
         {
-            key: "name_s",
-            short_tag: "n",
-            long_tag: "name",
-            spec: "string",
-            help: "A name"
+            key: 'name_s',
+            short_tag: 'n',
+            long_tag: 'name',
+            spec: 'string',
+            help: 'A name'
         }
     ];
     let result;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for interpreting backslash escape sequences (e.g., \n, \t, \xHH, \0NNN) in the echo command with the new -e/--interpret_escapes flag.

- **Bug Fixes**
  - Improved handling of output suppression with the \c escape sequence and the -n flag in the echo command.

- **Tests**
  - Expanded test coverage for the echo command, including comprehensive tests for the new escape sequence functionality.
  - Updated string formatting in argument parsing tests for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->